### PR TITLE
KusaReMKN バナー 横幅修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
                 <img src="/img/banner.png" width="117" height="30">
             </a>
             <a href="https://kusaremkn.com" target="_blank">
-                <img src="/img/kusaremkn.webp" width="117" height="30">
+                <img src="/img/kusaremkn.webp" width="85" height="30">
             </a>
         </footer>
     </body>


### PR DESCRIPTION
みかんちゃんのバナーを表示するための img タグにおいて、表示される画像の縦横比と一致しない値が指定されていたため、表示が崩れていました（やや横長に表示されていました）。この問題を修正します。
